### PR TITLE
[barras de repetição] Ajuste para casos especiais

### DIFF
--- a/hymn_pdf_generator/models.py
+++ b/hymn_pdf_generator/models.py
@@ -44,3 +44,31 @@ class Hymn(Configuration, MetaHymn):
                 font_size -= 1
 
         return font_size
+
+    def count_blank_lines(self, start_line, end_line) -> int:
+        """
+        Count the number of blank lines between the start and end line,
+        excluding blank lines when determining the end_line.
+
+        :param start_line: The start line starting by 0.
+        :param end_line: The end line starting by 0.
+        :return: The number of blank lines.
+        """
+        lines = self.text.split("\n")
+        non_blank_line_count = 0
+        actual_end_line = start_line
+
+        # Find the actual end line index considering only non-blank lines
+        for i, line in enumerate(lines[start_line:], start=start_line):
+            if line.strip():
+                non_blank_line_count += 1
+            if non_blank_line_count > end_line:
+                actual_end_line = i
+                break
+            actual_end_line = i
+
+        # Count blank lines in the range
+        return sum(
+            1 for line in lines[start_line:actual_end_line + 1]
+            if not line.strip()
+        )

--- a/hymn_pdf_generator/pdf_elements.py
+++ b/hymn_pdf_generator/pdf_elements.py
@@ -240,38 +240,45 @@ class HymnPDFGenerator(Configuration):
 
     def _build_vertical_lines(self, hymn: Hymn) -> List[VerticalLine]:
         """
-        Create vertical line elements based on hymn repetitions.
+        Create vertical line elements based on hymn bars repetitions.
 
         :param hymn: The hymn instance.
         :return: A list of VerticalLine elements.
         """
         elements = []
         allocator = RepetitionBarXAxisAllocator()
-        line_positions = allocator.get_entries_with_levels(hymn.repetitions)
+        bar_positions = allocator.get_entries_with_levels(hymn.repetitions)
 
         resize_factor = hymn.adjusted_font_size / self.default_body_font_size
+        def resize(number: int) -> float:
+            """Adjust in casa the font was resized to fit in page"""
+            return number * resize_factor
 
-        y_margin = -8 + (-4 * resize_factor)
-        one_line_height = 7 * resize_factor
-        space_between_lines = 9 * resize_factor
-        x_levels_distance = 6 * resize_factor
+        # Y padding
+        y_padding = -8 + resize(-4)
+        # X distance between bars
+        x_bars_distance = resize(6)
+        # Bar hight for one line
+        one_line = resize(7)
+        # Distance between two lines
+        between_lines = resize(9)
 
-        for line in line_positions:
-            start = line['start'] - 1
-            end = line['end'] - 1
-            level = line['level']
+        for bar in bar_positions:
+            start = bar['start'] - 1
+            end = bar['end'] - 1
+            level = bar['level']
 
             y_start = (
-                y_margin
-                - (start * one_line_height
-                   + start * space_between_lines)
+                y_padding
+                - (start * one_line
+                   + start * between_lines)
             )
             y_end = (
-                y_margin
-                - ((end + 1) * one_line_height
-                   + end * space_between_lines)
+                y_padding
+                - ((end + 1) * one_line
+                   + end * between_lines)
             )
-            x_position = -(level * x_levels_distance)
+            x_position = -(level * x_bars_distance)
 
             elements.append(
                 VerticalLine(x_position, y_start, y_end))

--- a/hymn_pdf_generator/pdf_elements.py
+++ b/hymn_pdf_generator/pdf_elements.py
@@ -250,7 +250,7 @@ class HymnPDFGenerator(Configuration):
         bar_positions = allocator.get_entries_with_levels(hymn.repetitions)
 
         resize_factor = hymn.adjusted_font_size / self.default_body_font_size
-        def resize(number: int) -> float:
+        def resize(number: float) -> float:
             """Adjust in casa the font was resized to fit in page"""
             return number * resize_factor
 
@@ -260,23 +260,32 @@ class HymnPDFGenerator(Configuration):
         x_bars_distance = resize(6)
         # Bar hight for one line
         one_line = resize(7)
+        # Bar hight for one blank line
+        one_blank_line = resize(8.5)
         # Distance between two lines
         between_lines = resize(9)
 
         for bar in bar_positions:
-            start = bar['start'] - 1
-            end = bar['end'] - 1
+            start = bar['start'] - 1  # Start from 0
+            end = bar['end'] - 1  # Start from 0
             level = bar['level']
 
+            blanks_before = hymn.count_blank_lines(0, start)
+            blanks_up_to_end = hymn.count_blank_lines(0, end)
+
+            # Calculate the bar vertical start and end positions
             y_start = (
                 y_padding
                 - (start * one_line
                    + start * between_lines)
+                - (blanks_before * one_blank_line)
             )
+
             y_end = (
                 y_padding
                 - ((end + 1) * one_line
                    + end * between_lines)
+                - (blanks_up_to_end * one_blank_line)
             )
             x_position = -(level * x_bars_distance)
 

--- a/hymn_pdf_generator/repetition_bar_allocator.py
+++ b/hymn_pdf_generator/repetition_bar_allocator.py
@@ -1,15 +1,18 @@
 from typing import List, Dict, Tuple
 
-class LevelAllocator:
+class RepetitionBarXAxisAllocator:
     """
-    A class to allocate levels to entries in the format "start-end".
+    A class to allocate the hymn repetition bars in different positions
+    avoiding them to be printed overlapping each other. It determines
+    the X axis for each bar.
 
-    The level means that each number can only allocate one entry.
-    The function will determine the level each entry is allocated based on previous allocations.
+    The function will determine the level (X axis) each entry is
+    allocated based on previous allocations ensuring bars on the same
+    hymn row number will be printed in different levels.
 
     Example:
         s = "1-2,3-4,1-4,2-3,3-5"
-        allocator = LevelAllocator()
+        allocator = RepetitionBarXAxisAllocator()
         levels = allocator.allocate_levels(s)  # Output: [1, 1, 2, 3, 4]
     """
 


### PR DESCRIPTION
A mudança feita por este PR (Pull Request) corrige a posição vertical das barras de repetição em casos que existem linhas em branco antes ou dentre as linhas que fazem parte da repetição. Abaixo uma imagem exemplificativa do antes e depois:
![image](https://github.com/user-attachments/assets/23973164-25f6-4e16-8b73-79515403d451)

![image](https://github.com/user-attachments/assets/b974691b-4b2b-4707-aa37-0c9f8b4740a9)
